### PR TITLE
Add `!default` suffix to overridable variables

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
-$md-font-path: "../fonts";
-$md-css-prefix: md;
+$md-font-path: "../fonts" !default;
+$md-css-prefix: md !default;
 $md-version: "1.1.1";
 
-$md-border-color: gray;
+$md-border-color: gray !default;


### PR DESCRIPTION
With this push request, developer can redeclare $md-font-path, $md-css-prefix and $md-border-color in their own SCSS files before they import material-design-iconic-font. So this is now easy to leave the library files untouched (which will allow for easier/automated update of the dependencies).

The default values are used only if no global variable with the same name already exists.