### PR TITLE
Main files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   ],
   "author": "Sergey Kupletsky <s.kupletsky@gmail.com> (http://github.com/zavoloklom)",
   "license": "MIT",
-  "main": "dist/material-design-iconic-font.css",
+  "main": "dist/css/material-design-iconic-font.css",
   "files": [
-    "dist/css/material-design-iconic-font.css",
+    "dist/css",
     "dist/fonts"
   ],
   "homepage": "https://zavoloklom.github.io/material-design-iconic-font/",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "main": "dist/css/material-design-iconic-font.css",
   "files": [
-    "dist/css",
+    "dist/css/material-design-iconic-font.css",
     "dist/fonts"
   ],
   "homepage": "https://zavoloklom.github.io/material-design-iconic-font/",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   ],
   "author": "Sergey Kupletsky <s.kupletsky@gmail.com> (http://github.com/zavoloklom)",
   "license": "MIT",
-  "main": [
-    "./dist/css/*",
-    "./dist/fonts/*"
+  "main": "dist/material-design-iconic-font.css",
+  "files": [
+    "dist/css/material-design-iconic-font.css",
+    "dist/fonts"
   ],
   "homepage": "https://zavoloklom.github.io/material-design-iconic-font/",
   "bugs": {


### PR DESCRIPTION
Hello !!

when I install it from npm, I receive the following error

![screen shot 2017-01-25 at 10 49 47](https://cloud.githubusercontent.com/assets/876227/22291121/db92c3bc-e2eb-11e6-8eb1-51155a916844.png)

as suggestion, following the npm package specs, the key `main` need be a string, not a array, e.g.

```json
{
  "main": "dist/material-design-iconic-font.css"
}
```

an, how you have other files, like fonts to be used, I suggest use another key from package to say that, I believe the right key is `files`, package doc says 'The "files" field is an array of files to include in your project'

So, in my PR, I commit the following

```json
{
  "main": "dist/css/material-design-iconic-font.css",
  "files": [
    "dist/css/material-design-iconic-font.css",
    "dist/fonts"
  ]
}
```

What you think?